### PR TITLE
Add tests for getJavaHome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:

--- a/src/__tests__/getJavaHome.test.ts
+++ b/src/__tests__/getJavaHome.test.ts
@@ -4,6 +4,10 @@ import { IJavaHomeInfo } from "locate-java-home/js/es5/lib/interfaces";
 describe("getJavaHome", () => {
   const originalEnv = process.env;
 
+  beforeEach(() => {
+    delete process.env.JAVA_HOME;
+  });
+
   afterEach(() => {
     process.env = originalEnv;
   });

--- a/src/__tests__/getJavaHome.test.ts
+++ b/src/__tests__/getJavaHome.test.ts
@@ -1,0 +1,119 @@
+import { getJavaHome } from "../getJavaHome";
+import { IJavaHomeInfo } from "locate-java-home/js/es5/lib/interfaces";
+
+describe("getJavaHome", () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("reads from configuration", async () => {
+    const javaHomeConfig = "/path/to/java";
+    const javaHome = await getJavaHome(javaHomeConfig);
+    expect(javaHome).toBe(javaHomeConfig);
+  });
+
+  it("reads from JAVA_HOME", async () => {
+    const JAVA_HOME = "/path/to/java";
+    process.env = { ...originalEnv, JAVA_HOME };
+    const javaHome = await getJavaHome(undefined);
+    expect(javaHome).toBe(JAVA_HOME);
+  });
+
+  it("prefers configuration to JAVA_HOME and installed Java", async () => {
+    const javaHomeConfig = "/path/to/config/java";
+    const JAVA_HOME = "/path/to/java";
+    process.env = { ...originalEnv, JAVA_HOME };
+    mockLocateJavaHome([java8Jdk, java11Jdk]);
+    const javaHome = await require("../getJavaHome").getJavaHome(
+      javaHomeConfig
+    );
+    expect(javaHome).toBe(javaHomeConfig);
+  });
+
+  // NOTE(gabro): we don't care about testing locate-java-home since it's an external dependency
+  // and we assume it works as expected. However, we want to test how we select a specific version
+  // when multiple installed Java are available.
+
+  it("falls back to installed Java", async () => {
+    mockLocateJavaHome([java8Jdk, java11Jdk]);
+    const javaHome = await require("../getJavaHome").getJavaHome(undefined);
+    expect(javaHome).toBe(java11Jdk.path);
+  });
+
+  it("prefers installed JDK over JRE", async () => {
+    mockLocateJavaHome([java11Jre, java8Jdk, java8Jre]);
+    const javaHome = await require("../getJavaHome").getJavaHome(undefined);
+    expect(javaHome).toBe(java8Jdk.path);
+  });
+
+  it("prefers the most recent installed JDK", async () => {
+    mockLocateJavaHome([java11Jdk, java8Jdk, java8Jre]);
+    const javaHome = await require("../getJavaHome").getJavaHome(undefined);
+    expect(javaHome).toBe(java11Jdk.path);
+  });
+
+  it("prefers the most recent security patch", async () => {
+    mockLocateJavaHome([java11Jdk, java11JdkNewPatch, java8Jre]);
+    const javaHome = await require("../getJavaHome").getJavaHome(undefined);
+    expect(javaHome).toBe(java11JdkNewPatch.path);
+  });
+});
+
+const java8Jdk = {
+  path: "/path/to/java8jdk",
+  version: "1.8.0",
+  security: 1,
+  isJDK: true
+};
+
+const java8Jre = {
+  path: "/path/to/java8jdk",
+  version: "1.8.0",
+  security: 1,
+  isJDK: false
+};
+
+const java11Jdk = {
+  path: "/path/to/java11jdk",
+  version: "1.11.0",
+  security: 1,
+  isJDK: true
+};
+
+const java11Jre = {
+  path: "/path/to/java11jdk",
+  version: "1.11.0",
+  security: 1,
+  isJDK: false
+};
+
+const java11JdkNewPatch = {
+  path: "/path/to/java11jdk/high/security",
+  version: "1.11.0",
+  security: 192,
+  isJDK: true
+};
+
+function mockLocateJavaHome(
+  javas: { path: string; version: string; security: number; isJDK: boolean }[]
+): void {
+  jest.resetModules();
+  jest
+    .spyOn(require("locate-java-home"), "default")
+    .mockImplementation((_options: unknown, cb: unknown) => {
+      (cb as (err: Error | null, found?: IJavaHomeInfo[]) => void)(
+        null,
+        javas.map(j => ({
+          ...j,
+          is64Bit: true,
+          executables: {
+            java: j.path + "/bin/java",
+            javac: j.path + "/bin/javac",
+            javap: j.path + "/bin/javap"
+          }
+        }))
+      );
+    });
+}

--- a/src/__tests__/getJavaOptions.test.ts
+++ b/src/__tests__/getJavaOptions.test.ts
@@ -25,7 +25,6 @@ describe("getJavaOptions", () => {
   });
 
   it("reads from JAVA_OPTS", () => {
-    jest.resetModules();
     process.env = { ...originalEnv, JAVA_OPTS: proxyOptions.join(" ") };
     const workspaceRoot = createWorskpace([]);
     const options = getJavaOptions(workspaceRoot);
@@ -33,7 +32,6 @@ describe("getJavaOptions", () => {
   });
 
   it("reads from JAVA_FLAGS", () => {
-    jest.resetModules();
     process.env = { ...originalEnv, JAVA_FLAGS: proxyOptions.join(" ") };
     const workspaceRoot = createWorskpace([]);
     const options = getJavaOptions(workspaceRoot);
@@ -41,7 +39,6 @@ describe("getJavaOptions", () => {
   });
 
   it("reads from multiple sources", () => {
-    jest.resetModules();
     const javaOpts = ["-Dsome.opt=1"];
     const javaFlags = ["-Jsome.flag=1", "-Jother.flag=2"];
     process.env = {


### PR DESCRIPTION
We test
- that we can read (in this order) from configuration, JAVA_HOME env, installed Java
- that we prefer JDK over JRE (so that we can index JDK sources), and then we select the most recent version (Java 11 over Java 8, and the most recent security patch)

As explained in the comment, we mock `locate-java-home` since it's an external dependency and we assume it works.