### PR TITLE
Add utilities to simplify fetching and launching Metals

### DIFF
--- a/src/fetchMetals.ts
+++ b/src/fetchMetals.ts
@@ -1,0 +1,50 @@
+import { ChildProcessPromise, spawn } from "promisify-child-process";
+import { JavaConfig } from "./getJavaConfig";
+
+interface FetchMetalsOptions {
+  serverVersion: string;
+  serverProperties: string[];
+  javaConfig: JavaConfig;
+}
+
+export function fetchMetals({
+  serverVersion,
+  serverProperties,
+  javaConfig: { javaPath, javaOptions, extraEnv, coursierPath }
+}: FetchMetalsOptions): ChildProcessPromise {
+  const fetchProperties = serverProperties.filter(
+    p => !p.startsWith("-agentlib")
+  );
+
+  return spawn(
+    javaPath,
+    [
+      ...javaOptions,
+      ...fetchProperties,
+      "-jar",
+      coursierPath,
+      "fetch",
+      "-p",
+      "--ttl",
+      // Use infinite ttl to avoid redunant "Checking..." logs when using SNAPSHOT
+      // versions. Metals SNAPSHOT releases are effectively immutable since we
+      // never publish the same version twice.
+      "Inf",
+      `org.scalameta:metals_2.12:${serverVersion}`,
+      "-r",
+      "bintray:scalacenter/releases",
+      "-r",
+      "sonatype:public",
+      "-r",
+      "sonatype:snapshots",
+      "-p"
+    ],
+    {
+      env: {
+        COURSIER_NO_TERM: "true",
+        ...extraEnv,
+        ...process.env
+      }
+    }
+  );
+}

--- a/src/getJavaConfig.ts
+++ b/src/getJavaConfig.ts
@@ -1,0 +1,39 @@
+import { getJavaOptions } from "./getJavaOptions";
+import * as path from "path";
+
+export interface JavaConfig {
+  javaOptions: string[];
+  javaPath: string;
+  coursierPath: string;
+  extraEnv: {
+    [k: string]: string | undefined;
+  };
+}
+
+interface GetJavaConfigOptions {
+  workspaceRoot: string | undefined;
+  javaHome: string;
+  extensionPath: string;
+  customRepositories: string[];
+}
+
+export function getJavaConfig({
+  workspaceRoot,
+  javaHome,
+  extensionPath,
+  customRepositories
+}: GetJavaConfigOptions): JavaConfig {
+  const javaOptions = getJavaOptions(workspaceRoot);
+  const javaPath = path.join(javaHome, "bin", "java");
+  const coursierPath = path.join(extensionPath, "./coursier");
+  const extraEnv = {
+    COURSIER_REPOSITORIES: customRepositories.join("|")
+  };
+
+  return {
+    javaOptions,
+    javaPath,
+    coursierPath,
+    extraEnv
+  };
+}

--- a/src/getServerOptions.ts
+++ b/src/getServerOptions.ts
@@ -1,0 +1,41 @@
+import { ServerOptions } from "./interfaces/ServerOptions";
+import { JavaConfig } from "./getJavaConfig";
+
+interface GetServerOptions {
+  metalsClasspath: string;
+  serverProperties: string[];
+  clientName: string;
+  doctorFormat: "html" | "json";
+  javaConfig: JavaConfig;
+}
+
+export function getServerOptions({
+  metalsClasspath,
+  serverProperties,
+  clientName,
+  doctorFormat,
+  javaConfig: { javaOptions, javaPath, extraEnv }
+}: GetServerOptions): ServerOptions {
+  const baseProperties = [
+    `-Dmetals.client=${clientName}`,
+    `-Dmetals.doctor-format=${doctorFormat}`,
+    "-Xss4m",
+    "-Xms100m"
+  ];
+  const mainArgs = ["-classpath", metalsClasspath, "scala.meta.metals.Main"];
+
+  // let user properties override base properties
+  const launchArgs = [
+    ...baseProperties,
+    ...javaOptions,
+    ...serverProperties,
+    ...mainArgs
+  ];
+
+  const env = { ...process.env, ...extraEnv };
+
+  return {
+    run: { command: javaPath, args: launchArgs, options: { env } },
+    debug: { command: javaPath, args: launchArgs, options: { env } }
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 export * from "./getJavaHome";
-export * from "./getJavaOptions";
 export * from "./downloadProgress";
 export * from "./isSupportedLanguage";
 export * from "./isDottyIdeEnabled";
 export * from "./detectLaunchConfigurationChanges";
 export * from "./checkServerVersion";
+export * from "./fetchMetals";
+export * from "./getServerOptions";
+export * from "./getJavaConfig";
 
 export * from "./commands/restartServer";

--- a/src/interfaces/ServerOptions.ts
+++ b/src/interfaces/ServerOptions.ts
@@ -1,0 +1,10 @@
+interface Executable {
+  command: string;
+  args?: string[];
+  options?: { env?: typeof process.env };
+}
+
+export interface ServerOptions {
+  run: Executable;
+  debug: Executable;
+}


### PR DESCRIPTION
Fetching the Metals jar and computing the launch options for the server is almost identical across coc-metals and VS Code. This PR addresses it.

NOTE: I'm taking baby steps from the implementation leaves, which means this could be deduplicated even further in the future (see for instance `getJavaOptions` which is now an implementation detail we don't expose anymore)