### PR TITLE
add readme and remove github-push-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,4 @@ jobs:
         run: yarn publish
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        run: git push origin HEAD:master

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# metals-languageclient
+Language client library for Node.js Metals clients
+
+![npm badge](https://img.shields.io/npm/v/metals-languageclient?logo=Language%20client%20for%20Node.js%20Metals%20clients&style=flat-square)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ce92ac.svg?style=flat-square)](https://github.com/prettier/prettier)
+
+### Metals
+
+See the website: [https://scalameta.org/metals/](https://scalameta.org/metals/)
+
+### Clients
+
+  - [coc-metals](https://github.com/scalameta/coc-metals)
+  - [metals-vscode](https://github.com/scalameta/metals-vscode)
+


### PR DESCRIPTION
This pr adds in a simple readme with links to Metals and the two clients utilizing this library.

It also removes github-push-action in favor of just using the checkout action.