### PR TITLE
remove no longer needed server property

### DIFF
--- a/src/getServerOptions.ts
+++ b/src/getServerOptions.ts
@@ -13,12 +13,10 @@ export function getServerOptions({
   metalsClasspath,
   serverProperties = [],
   clientName,
-  doctorFormat,
   javaConfig: { javaOptions, javaPath, extraEnv }
 }: GetServerOptions): ServerOptions {
   const baseProperties = [
     `-Dmetals.client=${clientName}`,
-    `-Dmetals.doctor-format=${doctorFormat}`,
     "-Xss4m",
     "-Xms100m"
   ];


### PR DESCRIPTION
Relating the this pr in Metals: https://github.com/scalameta/metals/pull/1414

Metals now has the ability to instead of getting this value as a server property, it can be passed in via `experimental` in `ClientCapabilities`.

The following to prs relate to this for the various clients.
https://github.com/scalameta/metals-vscode/pull/207
https://github.com/scalameta/coc-metals/pull/74
