### PR TITLE
remove doctorFormat from GetServerOptions Interface

### DIFF
--- a/src/getServerOptions.ts
+++ b/src/getServerOptions.ts
@@ -5,7 +5,6 @@ interface GetServerOptions {
   metalsClasspath: string;
   serverProperties: string[] | undefined;
   clientName: string;
-  doctorFormat: "html" | "json";
   javaConfig: JavaConfig;
 }
 


### PR DESCRIPTION
`doctorFormat` was removed from the `getServerOption` before, but not the Interface 😬 

This pr removes it from the interface.