### PR TITLE
Add in the ability to use addition restart triggers

### DIFF
--- a/src/detectLaunchConfigurationChanges.ts
+++ b/src/detectLaunchConfigurationChanges.ts
@@ -8,14 +8,16 @@ interface PromptRestartParams {
 
 export function detectLaunchConfigurationChanges(
   workspace: Workspace,
-  promptRestart: (params: PromptRestartParams) => Thenable<void>
+  promptRestart: (params: PromptRestartParams) => Thenable<void>,
+  additionalRestartKeys: string[] = []
 ): void {
   workspace.onDidChangeConfiguration(e => {
     const promptRestartKeys = [
       "serverVersion",
       "serverProperties",
       "javaHome",
-      "customRepositories"
+      "customRepositories",
+      ...additionalRestartKeys
     ];
     const shouldPromptRestart = promptRestartKeys.some(key =>
       e.affectsConfiguration(`metals.${key}`)


### PR DESCRIPTION
This pr adds the ability to pass in extra trigger keys to trigger a server restart. In https://github.com/scalameta/coc-metals/pull/94 I plan to introduce `metals.statusBarEnabled` which will allow a user to either set Metals to use `metals/status` or to default to `showMessages`. This will need to trigger a server restart since the value will be passed to metals via `clientExperimentalCapabilities`.