### PR TITLE
Don't call `onProgress` for stdout messages.

### DIFF
--- a/src/downloadProgress.ts
+++ b/src/downloadProgress.ts
@@ -19,7 +19,6 @@ export function downloadProgress({
   let stdout: Buffer[] = [];
   let stderr: Buffer[] = [];
   download.stdout?.on("data", (out: Buffer) => {
-    onProgress(out.toString());
     stdout.push(out);
   });
   download.stderr?.on("data", (err: Buffer) => {


### PR DESCRIPTION
Previously, when VS Code would always start a progress notification
window for "Downloading Metals" even when Metals was already cached
locally. Now, the notification window only appears when Metals is
actually being downloaded.

This fixes a small regression in the migration to metals-languageclient.
In the original VS Code implementation, we didn't call `onProgress()`
for stdout https://github.com/scalameta/metals-vscode/commit/051fe19c4e1b8e238d0372cf61b23cf16e3c4e42#diff-45327f86d4438556066de133327f4ca2L635-L637