### PR TITLE
support "-XX:+PrintCommandLineFlags" in .jvmOpts

### DIFF
--- a/src/__tests__/getJavaOptions.test.ts
+++ b/src/__tests__/getJavaOptions.test.ts
@@ -65,6 +65,13 @@ describe("getJavaOptions", () => {
     const options = getJavaOptions(workspaceRoot);
     expect(options).toEqual(proxyOptions);
   });
+
+  it("ignores PrintCommandLineFlags", () => {
+    const jvmOpts = ["-XX:+PrintCommandLineFlags", ...proxyOptions];
+    const workspaceRoot = createWorskpace(jvmOpts);
+    const options = getJavaOptions(workspaceRoot);
+    expect(options).toEqual(proxyOptions);
+  });
 });
 
 function createWorskpace(jvmOpts: string[]): string {

--- a/src/getJavaOptions.ts
+++ b/src/getJavaOptions.ts
@@ -27,7 +27,9 @@ function isValidOption(option: string): boolean {
     // memory requirements as for example the sbt build.
     !option.startsWith("-Xms") &&
     !option.startsWith("-Xmx") &&
-    !option.startsWith("-Xss")
+    !option.startsWith("-Xss") &&
+    // Do not alter stdout that we capture when using Coursier
+    option !== "-XX:+PrintCommandLineFlags"
   );
 }
 


### PR DESCRIPTION
The final classpath is built by looking at the output of the Coursier run fetching metals, so having any extra output results in an invalid classpath ("Error: -classpath requires class path specification").