### PR TITLE
Set JAVA_HOME to the value we use for Metals 

### DIFF
--- a/src/getJavaConfig.ts
+++ b/src/getJavaConfig.ts
@@ -28,6 +28,7 @@ export function getJavaConfig({
   const coursierPath = path.join(extensionPath, "./coursier");
   const extraEnv = {
     COURSIER_REPOSITORIES: customRepositories.join("|"),
+    JAVA_HOME: javaHome,
   };
 
   return {

--- a/src/getServerOptions.ts
+++ b/src/getServerOptions.ts
@@ -29,10 +29,10 @@ export function getServerOptions({
     ...mainArgs,
   ];
 
-  const env = { ...process.env, ...extraEnv };
+  const env = () => ({ ...process.env, ...extraEnv });
 
   return {
-    run: { command: javaPath, args: launchArgs, options: { env } },
-    debug: { command: javaPath, args: launchArgs, options: { env } },
+    run: { command: javaPath, args: launchArgs, options: { env: env() } },
+    debug: { command: javaPath, args: launchArgs, options: { env: env() } },
   };
 }


### PR DESCRIPTION
This is connected to the issues we've recently had on MacOS. There is a default binary there that looks for JAVA_HOME and if it is not set it will show a pop up. This is especially problematic for Bloop, which tries to use the default java binary and now we will show a pop up whenever the variable is not set and the default binary doesn't point to legitimate java version.

Fixes https://github.com/scalameta/metals/issues/1719

 This has two effects:
- we will add JAVA_HOME if it is not set
- we will replace any existing JAVA_HOME with the one used for Metals

We could also skip the second case, but I think it's sensible to set JAVA_HOME to the same value.

I also add @hedefalk  changes from https://github.com/hedefalk/metals-languageclient/commit/ce50e16d7d32a4db560d28e0d3d0502269a82ed8
