### PR TITLE
Add in the InitializationOptions from Metals

### DIFF
--- a/src/getServerOptions.ts
+++ b/src/getServerOptions.ts
@@ -4,7 +4,7 @@ import { JavaConfig } from "./getJavaConfig";
 interface GetServerOptions {
   metalsClasspath: string;
   serverProperties: string[] | undefined;
-  clientName: string;
+  clientName?: string;
   javaConfig: JavaConfig;
 }
 
@@ -14,11 +14,12 @@ export function getServerOptions({
   clientName,
   javaConfig: { javaOptions, javaPath, extraEnv },
 }: GetServerOptions): ServerOptions {
-  const baseProperties = [
-    `-Dmetals.client=${clientName}`,
-    "-Xss4m",
-    "-Xms100m",
-  ];
+  const baseProperties = ["-Xss4m", "-Xms100m"];
+
+  if (clientName) {
+    baseProperties.push(`-Dmetals.client=${clientName}`);
+  }
+
   const mainArgs = ["-classpath", metalsClasspath, "scala.meta.metals.Main"];
 
   // let user properties override base properties

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,4 @@ export * from "./installJava";
 
 export * from "./commands/restartServer";
 export * from "./interfaces/TreeViewProtocol";
+export * from "./interfaces/MetalsInitializationOptions";

--- a/src/interfaces/MetalsInitializationOptions.ts
+++ b/src/interfaces/MetalsInitializationOptions.ts
@@ -1,0 +1,32 @@
+interface CompilerInitializationOptions {
+  completionCommand?: string;
+  isCompletionItemDetailEnabled?: boolean;
+  isCompletionItemDocumentationEnabled?: boolean;
+  isCompletionItemResolve?: boolean;
+  isHoverDocumentationEnabled?: boolean;
+  isSignatureHelpDocumentationEnabled?: boolean;
+  overrideDefFormat?: "ascii" | "unicode";
+  parameterHintsCommand?: string;
+  snippetAutoIndent?: boolean;
+}
+
+export interface MetalsInitializationOptions {
+  compilerOptions?: CompilerInitializationOptions;
+  debuggingProvider?: boolean;
+  decorationProvider?: boolean;
+  didFocusProvider?: boolean;
+  doctorProvider?: "json" | "html";
+  executeClientCommandProvider?: boolean;
+  globSyntax?: "vscode" | "uri";
+  icons?: "vscode" | "octicons" | "atom" | "unicode";
+  inputBoxProvider?: boolean;
+  isExitOnShutdown?: boolean;
+  isHttpEnabled?: boolean;
+  openFilesOnRenameProvider?: boolean;
+  quickPickProvider?: boolean;
+  renameFileThreshold?: number;
+  slowTaskProvider?: boolean;
+  statusBarProvider?: "on" | "off" | "log-message" | "show-message";
+  treeViewProvider?: boolean;
+  openNewWindowProvider?: boolean;
+}


### PR DESCRIPTION
Now that https://github.com/scalameta/metals/pull/1903 has been merged, I'm getting started on [stage 2](https://github.com/scalameta/metals/issues/1895) outlined in here. This pr removes the `client` from `baseProperties` and then also adds in a `MetalsInitializationOptions` interface to make setting `initializationOptions` a little less error prone.