### PR TITLE
Add utf-8 to the process fetching Metals and fix downloading jabba 

### DIFF
--- a/src/fetchMetals.ts
+++ b/src/fetchMetals.ts
@@ -21,6 +21,7 @@ export function fetchMetals({
     [
       ...javaOptions,
       ...fetchProperties,
+      "-Dfile.encoding=UTF-8",
       "-jar",
       coursierPath,
       "fetch",

--- a/src/installJava.ts
+++ b/src/installJava.ts
@@ -30,14 +30,14 @@ export function installJava({
   const jabbaPath = path.join(bin, jabbaBinaryName());
 
   return mkdirp(bin)
-    .catch((err: Error) => {
-      console.debug(err);
-      outputChannel.appendLine(err.message);
-    })
     .then(() =>
-      download({ url: jabbaUrl, outputPath: jabbaPath, makeExecutable: true })
+      download({
+        url: jabbaUrl,
+        outputPath: jabbaPath,
+        makeExecutable: true,
+      })
     )
-    .then(() => pcp.exec(`${jabbaPath} ls-remote`))
+    .then(() => pcp.exec(`"${jabbaPath}" ls-remote`))
     .then((out) =>
       outputToString(out.stdout)
         .split("\n")
@@ -54,6 +54,11 @@ export function installJava({
         .then(() => outputChannel.appendLine(`${java} installed`))
         .then(() => pcp.exec(`${jabbaPath} which --home ${java}`))
         .then((e: pcp.Output) => outputToString(e.stdout).trim());
+    })
+    .catch((err: Error) => {
+      console.debug(err);
+      outputChannel.appendLine(err.message);
+      throw err;
     });
 }
 


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals-vscode/issues/366 and downloading with jabba when the executable has space in path.