### PR TITLE
Add copyWorksheetOutputProvider

### DIFF
--- a/src/interfaces/MetalsInitializationOptions.ts
+++ b/src/interfaces/MetalsInitializationOptions.ts
@@ -30,4 +30,5 @@ export interface MetalsInitializationOptions {
   statusBarProvider?: "on" | "off" | "log-message" | "show-message";
   treeViewProvider?: boolean;
   openNewWindowProvider?: boolean;
+  copyWorksheetOutputProvider?: boolean;
 }


### PR DESCRIPTION
This option is responsible for letting Metals server know that it can show additional lens in worksheet with the CopyWorksheetOutput client command.