### PR TITLE
Allow users to pass a full dependency string rather than just a version

### DIFF
--- a/src/fetchMetals.ts
+++ b/src/fetchMetals.ts
@@ -16,6 +16,10 @@ export function fetchMetals({
     (p) => !p.startsWith("-agentlib")
   );
 
+  const serverDependency = serverVersion.includes(":")
+    ? serverVersion
+    : `org.scalameta:metals_2.12:${serverVersion}`;
+
   return spawn(
     javaPath,
     [
@@ -31,7 +35,7 @@ export function fetchMetals({
       // versions. Metals SNAPSHOT releases are effectively immutable since we
       // never publish the same version twice.
       "Inf",
-      `org.scalameta:metals_2.12:${serverVersion}`,
+      serverDependency,
       "-r",
       "bintray:scalacenter/releases",
       "-r",


### PR DESCRIPTION
This change allows users to pass a full dependency string, like `com.something:metals_2.12:0.10.5-something-1`, rather than only a Metals version. This allows users to easily use their own fork of Metals if they want to, for example.

Passing a full dependency is optional: versions are still accepted, and are still assumed to correspond to `org.scalameta:metals_2.12`.