### PR TITLE
Exchange for locate-java-home honoring JAVA_HOME

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "fp-ts": "^2.4.1",
-    "locate-java-home": "^1.1.2",
+    "@hedefalk/locate-java-home": "^1.1.2",
     "mkdirp": "^1.0.3",
     "node-fetch": "^2.6.0",
     "promisify-child-process": "^4.0.0",

--- a/src/__tests__/getJavaHome.test.ts
+++ b/src/__tests__/getJavaHome.test.ts
@@ -1,5 +1,5 @@
 import { getJavaHome } from "../getJavaHome";
-import { IJavaHomeInfo } from "locate-java-home/js/es5/lib/interfaces";
+import { IJavaHomeInfo } from "@hedefalk/locate-java-home/js/es5/lib/interfaces";
 
 describe("getJavaHome", () => {
   const originalEnv = process.env;
@@ -118,7 +118,7 @@ function mockLocateJavaHome(
 ): void {
   jest.resetModules();
   jest
-    .spyOn(require("locate-java-home"), "default")
+    .spyOn(require("@hedefalk/locate-java-home"), "default")
     .mockImplementation((_options: unknown, cb: unknown) => {
       (cb as (err: Error | null, found?: IJavaHomeInfo[]) => void)(
         null,

--- a/src/getJavaHome.ts
+++ b/src/getJavaHome.ts
@@ -2,12 +2,12 @@ import { TaskEither, chain } from "fp-ts/lib/TaskEither";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as E from "fp-ts/lib/Either";
 import { pipe } from "fp-ts/lib/pipeable";
-import _locateJavaHome from "locate-java-home";
+import _locateJavaHome from "@hedefalk/locate-java-home";
 import * as semver from "semver";
 import {
   ILocateJavaHomeOptions,
   IJavaHomeInfo,
-} from "locate-java-home/js/es5/lib/interfaces";
+} from "@hedefalk/locate-java-home/js/es5/lib/interfaces";
 import { toPromise } from "./util";
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -235,6 +235,14 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@hedefalk/locate-java-home@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@hedefalk/locate-java-home/-/locate-java-home-1.1.2.tgz#11dd476e7b85f90a72c38e023d0305df1d1f9b1c"
+  integrity sha512-tlzL0SsDe3FdYTwEB+kE7Lmr2Px0YVNfMW1pF3KGU8gpqjeMYvpj+Eh27NkWvCscJxQs0dHUTuWEgJZhmvnn9Q==
+  dependencies:
+    async "^3.2.0"
+    semver "^7.3.4"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
@@ -725,12 +733,10 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-async@^2.6.1:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
-  dependencies:
-    lodash "^4.17.14"
+async@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.2.tgz#2eb7671034bb2194d45d30e31e24ec7e7f9670cd"
+  integrity sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -2363,14 +2369,6 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-locate-java-home@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/locate-java-home/-/locate-java-home-1.1.2.tgz#8cc6af243ad7ae4e53f0b8c3a671986750f69f36"
-  integrity sha512-cyylBBX0lBYYOpWGb5pJED40PZvFVru315HUaArT842bC5681AxOxbuQu0AlcNA+WCUBB+n0OQ21FaCKg9Jx5Q==
-  dependencies:
-    async "^2.6.1"
-    semver "^5.5.1"
-
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -2388,7 +2386,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+lodash@^4.17.13, lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3074,7 +3072,7 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -3084,7 +3082,7 @@ semver@6.x, semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.1.1:
+semver@^7.1.1, semver@^7.3.4:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals-vscode/issues/657

Both original https://github.com/jvilk/locate-java-home and fork https://github.com/jvilk/locate-java-home/pull/10#issuecomment-906193537

seems somewhat stale/dead so I just cross-published the fixed version under my user-scope on npm.

Don't know if there's a cleaner way, but it would really be nice to close https://github.com/scalameta/metals-vscode/issues/657