### PR TITLE
feature: automatically ugrade on latest snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "fp-ts": "^2.4.1",
     "mkdirp": "^1.0.3",
     "node-fetch": "^2.6.0",
+    "node-html-parser": "^5.2.0",
     "promisify-child-process": "^4.0.0",
     "semver": "^7.1.1",
     "shell-quote": "^1.7.2",

--- a/src/__tests__/snapshotVersionDate.tests.ts
+++ b/src/__tests__/snapshotVersionDate.tests.ts
@@ -1,0 +1,46 @@
+import * as V from "../checkServerVersion";
+
+describe("snapshotVersionsDate", () => {
+  it("parses-release", () => {
+    const v = "0.11.1";
+    const result = V.parseMetalsVersion(v);
+    const expected = new V.MetalsVersion(v, 0, 11, 1, undefined, undefined);
+    expect(result).toEqual(expected);
+  });
+
+  it("parses-old-snapshot", () => {
+    const v = "0.11.1+266-e916554b-SNAPSHOT";
+    const result = V.parseMetalsVersion(v);
+    const expected = new V.MetalsVersion(v, 0, 11, 1, 266, undefined);
+    expect(result).toEqual(expected);
+  });
+
+  it("parses-new-snapshot", () => {
+    const v = "0.11.1+266-e916554b-20220125-SNAPSHOT";
+    const result = V.parseMetalsVersion(v);
+    const expected = new V.MetalsVersion(v, 0, 11, 1, 266, "20220125");
+    expect(result).toEqual(expected);
+  });
+
+  it("sort correctly", () => {
+    const versions = [
+      "0.11.1",
+      "0.11.0+999-e916554b-SNAPSHOT",
+      "0.11.1+1-e916554b-SNAPSHOT",
+      "0.11.2+10-e916554b-20200219-SNAPSHOT",
+      "0.11.1+0-e916554b-SNAPSHOT",
+    ]
+      .map((v) => V.parseMetalsVersion(v))
+      .filter((v): v is V.MetalsVersion => !!v);
+
+    const sorted = versions.sort((a, b) => a.compareTo(b)).map((a) => a.value);
+
+    expect(sorted).toEqual([
+      "0.11.0+999-e916554b-SNAPSHOT",
+      "0.11.1",
+      "0.11.1+0-e916554b-SNAPSHOT",
+      "0.11.1+1-e916554b-SNAPSHOT",
+      "0.11.2+10-e916554b-20200219-SNAPSHOT",
+    ]);
+  });
+});

--- a/src/checkServerVersion.ts
+++ b/src/checkServerVersion.ts
@@ -1,6 +1,7 @@
 import { WorkspaceConfiguration } from "./interfaces/WorkspaceConfiguration";
 import { ConfigurationTarget } from "./interfaces/ConfigurationTarget";
-import * as semver from "semver";
+import http from "https";
+import { parse } from "node-html-parser";
 
 interface OnOutdatedParams {
   message: string;
@@ -31,31 +32,71 @@ export async function checkServerVersion({
 }: CheckServerVersionParams) {
   const { serverVersion, latestServerVersion, configurationTarget } =
     serverVersionInfo(config);
-  const isOutdated = (() => {
-    try {
-      return semver.lt(serverVersion, latestServerVersion);
-    } catch (_e) {
-      // serverVersion has an invalid format
-      // ignore the exception here, and let subsequent checks handle this
-      return false;
+
+  const latestParsed = parseMetalsVersion(latestServerVersion);
+  const curentParsed = parseMetalsVersion(serverVersion);
+
+  if (latestParsed && curentParsed) {
+    const isOutdated = curentParsed.lt(latestParsed);
+
+    const lookupNewest = (() => {
+      if (curentParsed.date) {
+        const date = new Date();
+        const today =
+          `${date.getUTCFullYear}` +
+          `${("0" + (date.getUTCMonth() + 1)).slice(-2)}` +
+          `${("0" + (date.getUTCDay() + 1)).slice(-2)}`;
+        // do not upgrade several times per day
+        return curentParsed.date != today;
+      } else {
+        return true;
+      }
+    })();
+
+    const autoLatest = config.get<boolean>("autoLatestSnapshot");
+
+    const askUpgradeOn = (async () => {
+      if (autoLatest && lookupNewest) {
+        const snapshots = await loadSnapshotVersions();
+        const greater = snapshots.filter((v) => curentParsed.lt(v));
+        const sorted = greater.sort((a, b) => a.compareTo(b));
+        if (sorted.length > 0) {
+          return sorted[sorted.length - 1];
+        } else if (isOutdated) {
+          return latestParsed;
+        } else {
+          return undefined;
+        }
+      } else if (isOutdated) {
+        return latestParsed;
+      } else {
+        return undefined;
+      }
+    })();
+
+    const nextVersion = await askUpgradeOn;
+    if (nextVersion) {
+      const message = nextVersion.isSnapshot()
+        ? `New snapshot version ${nextVersion.value} is available`
+        : `You are running an out-of-date version of Metals. The latest version is ${nextVersion.value}, but you have configured a custom server version ${serverVersion}`;
+      const upgradeChoice = `Upgrade to ${nextVersion.value} now`;
+      const openSettingsChoice = "Open settings";
+      const dismissChoice = "Not now";
+      const upgrade = () =>
+        updateConfig({
+          configSection,
+          latestServerVersion,
+          configurationTarget,
+        });
+
+      onOutdated({
+        message,
+        upgradeChoice,
+        openSettingsChoice,
+        dismissChoice,
+        upgrade,
+      });
     }
-  })();
-
-  if (isOutdated) {
-    const message = `You are running an out-of-date version of Metals. The latest version is ${latestServerVersion}, but you have configured a custom server version ${serverVersion}`;
-    const upgradeChoice = `Upgrade to ${latestServerVersion} now`;
-    const openSettingsChoice = "Open settings";
-    const dismissChoice = "Not now";
-    const upgrade = () =>
-      updateConfig({ configSection, latestServerVersion, configurationTarget });
-
-    onOutdated({
-      message,
-      upgradeChoice,
-      openSettingsChoice,
-      dismissChoice,
-      upgrade,
-    });
   }
 }
 
@@ -81,4 +122,121 @@ function serverVersionInfo(config: WorkspaceConfiguration): {
     latestServerVersion: defaultValue!,
     configurationTarget,
   };
+}
+
+export function loadSnapshotVersions(): Promise<MetalsVersion[]> {
+  const url =
+    "https://oss.sonatype.org/content/repositories/snapshots/org/scalameta/metals_2.12/";
+  const ps = new Promise<string>((resolve, reject) => {
+    http.get(url, (resp) => {
+      let body = "";
+      resp.on("data", (chunk) => (body += chunk));
+      resp.on("end", () => resolve(body));
+      resp.on("error", (e) => reject(e));
+    });
+  });
+
+  return ps.then((text) => {
+    const root = parse(text);
+    const versions = root.getElementsByTagName("tr").flatMap((e) => {
+      const elem = e.getElementsByTagName("td")[0];
+      if (elem) {
+        const text = elem.text;
+        if (text.endsWith("/")) {
+          const parsed = parseMetalsVersion(text);
+          return parsed ? [parsed] : [];
+        } else {
+          return [];
+        }
+      } else {
+        return [];
+      }
+    });
+
+    return versions;
+  });
+}
+
+export class MetalsVersion {
+  value: string;
+
+  major: number;
+  minor: number;
+  patch: number;
+
+  commitNum?: number;
+  date?: string;
+
+  constructor(
+    value: string,
+    major: number,
+    minor: number,
+    patch: number,
+    commitNum?: number,
+    date?: string
+  ) {
+    this.value = value;
+    this.major = major;
+    this.minor = minor;
+    this.patch = patch;
+    this.commitNum = commitNum;
+    this.date = date;
+  }
+
+  compareTo(other: MetalsVersion): number {
+    function asList(v: MetalsVersion): number[] {
+      return [v.major, v.minor, v.patch, v.commitNum ? v.commitNum : 0];
+    }
+    const one = asList(this);
+    const two = asList(other);
+
+    var out = 0;
+    var idx = 0;
+    while (out == 0 && idx < one.length) {
+      const diff = one[idx] - two[idx];
+      if (diff != 0) {
+        out = diff;
+      }
+      idx = idx + 1;
+    }
+    return out;
+  }
+
+  isSnapshot(): boolean {
+    return this.commitNum ? true : false;
+  }
+
+  lt(other: MetalsVersion): boolean {
+    return this.compareTo(other) < 0;
+  }
+
+  gt(other: MetalsVersion): boolean {
+    return !this.lt(other);
+  }
+}
+
+export function parseMetalsVersion(value: string): MetalsVersion | undefined {
+  const regex =
+    /(\d+)\.(\d+)\.(\d+)((\+(\d+))-[0-9a-z]{8}(-(\d{8}))?-SNAPSHOT)?/;
+  const matcher = value.match(regex);
+  if (matcher) {
+    const major = matcher[1];
+    const minor = matcher[2];
+    const patch = matcher[3];
+    const commitNum = matcher[6];
+
+    const date = matcher[8];
+
+    const version = new MetalsVersion(
+      value,
+      parseInt(major),
+      parseInt(minor),
+      parseInt(patch),
+      commitNum ? parseInt(commitNum) : undefined,
+      date
+    );
+    return version;
+  } else {
+    return undefined;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,6 +841,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1085,6 +1090,22 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-select@^4.1.3:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.2.1.tgz#9e665d6ae4c7f9d65dbe69d0316e3221fb274cdd"
+  integrity sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^5.1.0"
+    domhandler "^4.3.0"
+    domutils "^2.8.0"
+    nth-check "^2.0.1"
+
+css-what@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe"
+  integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
+
 cssom@^0.4.1:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
@@ -1194,12 +1215,42 @@ diff-sequences@^27.0.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
   integrity sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
 
+dom-serializer@^1.0.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
+
+domelementtype@^2.0.1, domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+
 domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
   integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
   dependencies:
     webidl-conversions "^4.0.2"
+
+domhandler@^4.2.0, domhandler@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.0.tgz#16c658c626cf966967e306f966b431f77d4a5626"
+  integrity sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==
+  dependencies:
+    domelementtype "^2.2.0"
+
+domutils@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -1220,6 +1271,11 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+entities@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1581,6 +1637,11 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -2559,6 +2620,14 @@ node-fetch@^2.6.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-html-parser@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-5.2.0.tgz#6f29fd00d79f65334e7e20200964644207925607"
+  integrity sha512-fmiwLfQu+J2A0zjwSEkztSHexAf5qq/WoiL/Hgo1K7JpfEP+OGWY5maG0kGaM+IFVdixF/1QbyXaQ3h4cGfeLw==
+  dependencies:
+    css-select "^4.1.3"
+    he "1.2.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -2615,6 +2684,13 @@ npm-run-path@^4.0.0:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+nth-check@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
+  integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
+  dependencies:
+    boolbase "^1.0.0"
 
 nwsapi@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
This add an option to automatically upgrade server version on the latest
SNAPSHOT once a day.

New setting name: `autoLatestSnapshot`

Requires: https://github.com/scalameta/metals/pull/3568