### PR TITLE
Change displayBuildTarget to listBuildTargets

### DIFF
--- a/src/interfaces/ClientCommands.ts
+++ b/src/interfaces/ClientCommands.ts
@@ -33,8 +33,6 @@ export const ClientCommands = {
   ReloadDoctor: "metals-doctor-reload",
   /** Focus on a window displaying troubleshooting help from the Metals doctor. */
   RunDoctor: "metals-doctor-run",
-  /** Show details about a specific build target */
-  DisplayTargetInfo: "metals-target-info-display",
   /**
    * Command to trigger a debug session with Metals. Triggered by a code lens
    * in the editor.

--- a/src/interfaces/ServerCommands.ts
+++ b/src/interfaces/ServerCommands.ts
@@ -66,8 +66,8 @@ export const ServerCommands = {
   DoctorRun: "doctor-run",
   /** Decode a file to human readable format.  E.g. class, semanticdb */
   DecodeFile: "file-decode",
-  /** Prompt for build targets and get info about selected */
-  DisplayTargetInfo: "target-info-display",
+  /** Retrieve a list of all build targets */
+  ListBuildTargets: "list-build-targets",
   /**
    * Detect the build tool for a workspace and generate the bsp config for the
    * build tool. If there are multiple build tools for a workspace ,the user


### PR DESCRIPTION
See https://github.com/scalameta/metals-vscode/pull/893

This also removes the client command - I think I added that by mistake - should have just been server command