### PR TITLE
feat: support new 2.13 artifacts

### DIFF
--- a/src/__tests__/fetchMetals.test.ts
+++ b/src/__tests__/fetchMetals.test.ts
@@ -1,0 +1,32 @@
+import { calcServerDependency } from "../fetchMetals";
+
+describe("fetchMetals", () => {
+  describe("calcServerDependency", () => {
+    function expectedDep(binaryVersion: string, serverVersion: string): string {
+      return `org.scalameta:metals_${binaryVersion}:${serverVersion}`;
+    }
+    it("should download from appropriate binaryVersion", () => {
+      expect(calcServerDependency("0.11.1")).toBe(
+        expectedDep("2.12", "0.11.1")
+      );
+      expect(calcServerDependency("0.11.2")).toBe(
+        expectedDep("2.12", "0.11.2")
+      );
+      expect(calcServerDependency("0.11.2-SNAPSHOT")).toBe(
+        expectedDep("2.12", "0.11.2-SNAPSHOT")
+      );
+      expect(calcServerDependency("0.11.2-RC1")).toBe(
+        expectedDep("2.12", "0.11.2-RC1")
+      );
+      expect(calcServerDependency("0.11.3")).toBe(
+        expectedDep("2.13", "0.11.3")
+      );
+      expect(calcServerDependency("0.11.3-SNAPSHOT")).toBe(
+        expectedDep("2.13", "0.11.3-SNAPSHOT")
+      );
+      expect(calcServerDependency("0.11.3-RC1")).toBe(
+        expectedDep("2.13", "0.11.3-RC1")
+      );
+    });
+  });
+});

--- a/src/fetchMetals.ts
+++ b/src/fetchMetals.ts
@@ -1,3 +1,4 @@
+import * as semver from "semver";
 import { ChildProcessPromise, spawn } from "promisify-child-process";
 import { JavaConfig } from "./getJavaConfig";
 
@@ -16,11 +17,7 @@ export function fetchMetals({
     (p) => !p.startsWith("-agentlib")
   );
 
-  const binaryVersion = serverVersion > "0.11.2" ? "2.13" : "2.12";
-  const serverDependency = serverVersion.includes(":")
-    ? serverVersion
-    : `org.scalameta:metals_${binaryVersion}:${serverVersion}`;
-
+  const serverDependency = calcServerDependency(serverVersion);
   return spawn(
     javaPath,
     [
@@ -54,4 +51,11 @@ export function fetchMetals({
       stdio: ["ignore"], // Due to Issue: #219
     }
   );
+}
+
+export function calcServerDependency(serverVersion: string): string {
+  const binaryVersion = semver.gt(serverVersion, "0.11.2") ? "2.13" : "2.12";
+  return serverVersion.includes(":")
+    ? serverVersion
+    : `org.scalameta:metals_${binaryVersion}:${serverVersion}`;
 }

--- a/src/fetchMetals.ts
+++ b/src/fetchMetals.ts
@@ -16,9 +16,10 @@ export function fetchMetals({
     (p) => !p.startsWith("-agentlib")
   );
 
+  const binaryVersion = serverVersion > "0.11.2" ? "2.13" : "2.12";
   const serverDependency = serverVersion.includes(":")
     ? serverVersion
-    : `org.scalameta:metals_2.12:${serverVersion}`;
+    : `org.scalameta:metals_${binaryVersion}:${serverVersion}`;
 
   return spawn(
     javaPath,


### PR DESCRIPTION
This PR is the same as https://github.com/scalameta/nvim-metals/pull/346

(As of https://github.com/scalameta/metals/pull/3631 we now have 2.13 artifacts instead of 2.12).

Confirmed we can download `publishLocal`ed metals server `0.11.13-SNAPSHOT` with this

- `yarn link` in this repo
- `yarn link "metals-languageclient"` in `metals-vscode`
- Run extension by `F5`