### PR TITLE
refactor: use `function.pipe` instead of `pipeable.pipe`

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import { TaskEither } from "fp-ts/lib/TaskEither";
-import { pipe } from "fp-ts/lib/pipeable";
+import { pipe } from "fp-ts/lib/function";
 import * as E from "fp-ts/lib/Either";
 
 export function toPromise<E, A>(te: TaskEither<E, A>): Promise<A> {


### PR DESCRIPTION
The `pipeable.pipe` is deprecated in fp-ts `2.10.0`

> https://github.com/gcanti/fp-ts/commit/cf2eb5f522d7f7d59686ceb53000545ee3cfed69#diff-525b26146709ecb0afacc1b32b888c93d30565ae689cb87349c329ab34e9520cR1563