### PR TITLE
feat: add `openjdk@1.17` to type of JavaVersion

### DIFF
--- a/src/installJava.ts
+++ b/src/installJava.ts
@@ -11,7 +11,7 @@ import { TranscodeEncoding } from "buffer";
 
 const defaultJabbaVersion = "0.11.2";
 
-type JavaVersion = "adopt@1.8" | "adopt@1.11";
+type JavaVersion = "adopt@1.8" | "adopt@1.11" | "openjdk@1.17";
 
 interface InstallJavaOptions {
   javaVersion: JavaVersion;


### PR DESCRIPTION
As is the title.

I selected the `openjdk@1.17`. Is this a no problem?

```sh
$ jabba ls-remote | grep 17
amazon-corretto@1.17.0-0.35.1
openjdk@1.17.0
openjdk-ri@1.17.0
zulu@1.17.0-0
zulu@1.8.172
zulu@1.7.171
```

Thank you :)