### PR TITLE
ci: trigger release workflow when GH release is created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "v*.*.*"
+  release:
+    types:
+      - published
 
 jobs:
   release:


### PR DESCRIPTION
It's easier to create release from GH than pushing a tag and then creating GH release