### PR TITLE
Support custom Metals server version again

### DIFF
--- a/src/__tests__/fetchMetals.test.ts
+++ b/src/__tests__/fetchMetals.test.ts
@@ -30,6 +30,8 @@ describe("fetchMetals", () => {
       expect(calcServerDependency("0.11.2+32-536ff4b1-SNAPSHOT")).toBe(
         expectedDep("2.13", "0.11.2+32-536ff4b1-SNAPSHOT")
       );
+      const customVersion = "com.acme:metals_1.2.3:3.2.1-foobar";
+      expect(calcServerDependency(customVersion)).toBe(customVersion);
     });
   });
 });

--- a/src/fetchMetals.ts
+++ b/src/fetchMetals.ts
@@ -54,11 +54,14 @@ export function fetchMetals({
 }
 
 export function calcServerDependency(serverVersion: string): string {
-  const use213 =
-    semver.gt(serverVersion, "0.11.2") ||
-    (serverVersion.startsWith("0.11.2") && serverVersion.endsWith("SNAPSHOT"));
-  const binaryVersion = use213 ? "2.13" : "2.12";
-  return serverVersion.includes(":")
-    ? serverVersion
-    : `org.scalameta:metals_${binaryVersion}:${serverVersion}`;
+  if (serverVersion.includes(":")) {
+    return serverVersion;
+  } else {
+    const use213 =
+      semver.gt(serverVersion, "0.11.2") ||
+      (serverVersion.startsWith("0.11.2") &&
+        serverVersion.endsWith("SNAPSHOT"));
+    const binaryVersion = use213 ? "2.13" : "2.12";
+    return `org.scalameta:metals_${binaryVersion}:${serverVersion}`;
+  }
 }


### PR DESCRIPTION
When Metals was migrated to Scala 2.13, this library became responsible
for determining whether artifacts for Scala 2.12 or 2.13 should be
downloaded. This decision was made by comparing the user-provided
version with the version of Metals that first introduced 2.13. The
versions are compared with semver.

At the same time, this component supports passing complete Maven
coordinates (ie. `org:name:version`), which the semver library will not
be able to parse. Because parsing fails, Metals will not be started and
an error will be reported.

This commit fixes this by not trying to guess the Scala version of the
artifacts to download when complete coordinates are given.

I verified this fixes the problem with:
- `yarn link` in this repo
- `yarn link "metals-languageclient"` in metals-vscode
- Run extension by F5