### PR TITLE
refactor: Remove unused abstract members from LanguageClient

### DIFF
--- a/src/interfaces/LanguageClient.ts
+++ b/src/interfaces/LanguageClient.ts
@@ -1,9 +1,7 @@
 import {
-  RequestType,
   RequestType0,
   CancellationToken,
   NotificationType0,
-  NotificationType,
 } from "vscode-languageserver-protocol";
 
 export interface LanguageClient {
@@ -11,19 +9,5 @@ export interface LanguageClient {
     type: RequestType0<R, E>,
     token?: CancellationToken
   ): Thenable<R>;
-  sendRequest<P, R, E, RO>(
-    type: RequestType<P, R, E>,
-    params: P,
-    token?: CancellationToken
-  ): Thenable<R>;
-  sendRequest<R>(method: string, token?: CancellationToken): Thenable<R>;
-  sendRequest<R>(
-    method: string,
-    param: any,
-    token?: CancellationToken
-  ): Thenable<R>;
   sendNotification(type: NotificationType0): void;
-  sendNotification<P>(type: NotificationType<P>, params?: P): void;
-  sendNotification(method: string): void;
-  sendNotification(method: string, params: any): void;
 }


### PR DESCRIPTION
vscode-languageclient to 8.0.1 modified the signatures of the
LanguageClient and it doesn't match with the LanguageClient interface
defined in this package.
see: https://github.com/scalameta/metals-vscode/pull/983

Not sure why these abstract members were needed: looks like
LanguageClient requires only two members, and others are unused.

Removing other unused abstract members from `LanguageClient` in metals-language-client
so that it matches the signature of `LanguageClient` from
vscode-languageclient.