### PR TITLE
Update node version of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: "10.x"
+          node-version: "14.x"
 
       - name: Setup git env
         run: |


### PR DESCRIPTION
see: https://github.com/scalameta/metals-languageclient/runs/6752667431?check_suite_focus=true

```
error vscode-jsonrpc@8.0.1: The engine "node" is incompatible with this module. Expected version ">=14.0.0". Got "10.24.1"
```